### PR TITLE
Filter support for Leaderboard API

### DIFF
--- a/src/api/leaderboard/controller.js
+++ b/src/api/leaderboard/controller.js
@@ -1,78 +1,50 @@
 const prisma = require("../../utils/PrismaClient");
 
-const getLeaderboard = async (req, res) => {
-  const { page = 1, limit = 10 } = req.query; // Get page and limit from query parameters with default values
-
-  try {
-    const users = await prisma.users.findMany({
-      skip: (parseInt(page) - 1) * parseInt(limit), // Pagination logic
-      take: parseInt(limit),
-      orderBy: {
-        points: "desc", // Sort by points in descending order
-      },
-      select: {
-        name: true,
-        githubId: true,
-        points: true,
-        avatar: true,
-        _count: {
-          select: {
-            prs: true, // Count of all PRs
-          },
+const formatUsers = (users, allUsers) => {
+  return users.map((user) => {
+    // Calculate PR statistics
+    const prStats = user.prs.reduce(
+        (acc, pr) => {
+          switch (pr.state.toLowerCase()) {
+            case "open":
+              acc.opened++;
+              break;
+            case "closed":
+              acc.closed++;
+              break;
+            case "merged":
+              acc.merged++;
+              break;
+          }
+          return acc;
         },
-        prs: {
-          select: {
-            state: true, // Select the status of each PR
-          },
-        },
+        { opened: 0, closed: 0, merged: 0 }
+    );
+
+    // Calculate user's rank
+    const rank = allUsers.findIndex((u) => u.points <= user.points) + 1;
+
+    // Format the user
+    return {
+      name: user.name,
+      githubId: user.githubId,
+      points: user.points,
+      avatar: user.avatar,
+      prs: {
+        opened: prStats.opened,
+        closed: prStats.closed,
+        merged: prStats.merged,
       },
-    });
+      rank,
+    };
+  });
+}
 
-    // Count total users for pagination metadata
-    const totalUsers = await prisma.users.count();
-
-    // Transform the users data to include counts of opened, closed, and merged PRs
-    const transformedUsers = users.map((user, index) => {
-      const prCounts = {
-        opened: 0,
-        closed: 0,
-        merged: 0,
-      };
-
-      user.prs.forEach((pr) => {
-        if (pr.state === "opened") prCounts.opened++;
-        if (pr.state === "closed") prCounts.closed++;
-        if (pr.state === "merged") prCounts.merged++;
-      });
-      user.prs = prCounts;
-      delete user._count;
-      return {
-        ...user,
-        rank: (parseInt(page) - 1) * parseInt(limit) + index + 1, // Calculate rank
-      };
-    });
-
-    res.json({
-      contributors: transformedUsers,
-      meta: {
-        currentPage: parseInt(page),
-        totalPages: Math.ceil(totalUsers / limit),
-        totalUsers: totalUsers,
-      },
-    });
-  } catch (error) {
-    console.error("Error fetching leaderboard:", error);
-    res.status(500).send("Error fetching leaderboard");
-  }
-};
-
-const searchUser = async (req, res) => {
-  const { name } = req.query;
+const filterByUser = async (req, res) => {
+  const { name, page = 1, limit = 10  } = req.query;
   //validate the name
   if (!name || name.trim() === "") {
-    return res.status(400).json({
-      error: "Please provide a valid name for search",
-    });
+    return filterLeaderboard(req, res);
   }
 
   try {
@@ -89,6 +61,8 @@ const searchUser = async (req, res) => {
 
     // Find all matching users with all required fields
     const users = await prisma.users.findMany({
+      skip: (parseInt(page) - 1) * parseInt(limit), // Pagination logic
+      take: parseInt(limit),
       where: {
         OR: [
           {
@@ -115,49 +89,26 @@ const searchUser = async (req, res) => {
     });
 
     if (!users || users.length === 0) {
-      return res.json({ data: [] });
+      return res.json({
+        contributors: [],
+        meta: {
+          currentPage: 1,
+          totalPages: 1,
+          totalUsers: 0,
+        } });
     }
 
-    // Format all matching users
-    const formattedUsers = users.map((user) => {
-      // Calculate PR statistics
-      const prStats = user.prs.reduce(
-        (acc, pr) => {
-          switch (pr.state.toLowerCase()) {
-            case "open":
-              acc.opened++;
-              break;
-            case "closed":
-              acc.closed++;
-              break;
-            case "merged":
-              acc.merged++;
-              break;
-          }
-          return acc;
-        },
-        { opened: 0, closed: 0, merged: 0 }
-      );
+    // Transform the users data to include counts of opened, closed, and merged PRs
+    const formattedUsers = formatUsers(users, allUsers);
 
-      // Calculate user's rank
-      const rank = allUsers.findIndex((u) => u.points <= user.points) + 1;
-
-      // Format the user
-      return {
-        name: user.name,
-        githubId: user.githubId,
-        points: user.points,
-        avatar: user.avatar,
-        prs: {
-          opened: prStats.opened,
-          closed: prStats.closed,
-          merged: prStats.merged,
-        },
-        rank,
-      };
+    res.json({
+      contributors: formattedUsers,
+      meta: {
+        currentPage: parseInt(page),
+        totalPages: Math.ceil(allUsers.length / limit) || 1,
+        totalUsers: allUsers.length,
+      }
     });
-
-    res.json({ data: formattedUsers });
   } catch (error) {
     console.error("Error searching users:", error);
     res.status(500).send("Error searching users");
@@ -165,10 +116,26 @@ const searchUser = async (req, res) => {
 };
 
 const filterLeaderboard = async (req, res) => {
-  const { minPoints, maxPoints, minPrs } = req.query;
+  const {minPoints, maxPoints, minPrs, page = 1, limit = 10, name} = req.query;
 
   try {
+    // First get all users ordered by points to calculate rank
+    const allUsers = await prisma.users.findMany({
+      orderBy: {
+        points: "desc",
+      },
+      select: {
+        githubId: true,
+        points: true,
+      },
+    });
+
     const users = await prisma.users.findMany({
+      skip: (parseInt(page) - 1) * parseInt(limit), // Pagination logic
+      take: parseInt(limit),
+      orderBy: {
+        points: "desc",
+      },
       where: {
         points: {
           gte: parseInt(minPoints) || 0, // Filter users with at least minPoints (default 0)
@@ -176,20 +143,22 @@ const filterLeaderboard = async (req, res) => {
         },
         prs: {
           some: {
-            id: {
+            prNumber: {
               gte: parseInt(minPrs) || 0, // Filter users with at least minPrs
             },
           },
         },
-      },
-      orderBy: {
-        points: "desc",
       },
       select: {
         name: true,
         githubId: true,
         points: true,
         avatar: true,
+        _count: {
+          select: {
+            prs: true, // Count of all PRs
+          },
+        },
         prs: {
           select: {
             prNumber: true,
@@ -200,7 +169,19 @@ const filterLeaderboard = async (req, res) => {
       },
     });
 
-    res.json({ data: users });
+    const totalUsers = await prisma.users.count();
+
+    // Transform the users data to include counts of opened, closed, and merged PRs
+    const formattedUsers = formatUsers(users, allUsers);
+
+    res.json({
+      contributors: formattedUsers || [],
+      meta: {
+        currentPage: parseInt(page),
+        totalPages: Math.ceil(totalUsers / limit) || 1,
+        totalUsers: totalUsers,
+      },
+    });
   } catch (error) {
     console.error("Error filtering users:", error);
     res.status(500).send("Error filtering users");
@@ -208,7 +189,6 @@ const filterLeaderboard = async (req, res) => {
 };
 
 module.exports = {
-  getLeaderboard,
-  searchUser,
+  filterByUser,
   filterLeaderboard,
 };

--- a/src/api/leaderboard/controller.js
+++ b/src/api/leaderboard/controller.js
@@ -144,7 +144,7 @@ const filterByUsers = async (req, res) => {
     });
   } catch (error) {
     console.error("Error searching users:", error);
-    res.status(500).send("Error searching users"+error.message);
+    res.status(500).send("Error searching users");
   }
 };
 

--- a/src/api/leaderboard/index.js
+++ b/src/api/leaderboard/index.js
@@ -4,8 +4,8 @@ const { verifyJWT } = require('../../utils/Middlewares');
 
 const router = Router();
 
-router.get('/', controller.getLeaderboard);
-router.get('/search', controller.searchUser);
-router.get('/filter', controller.filterLeaderboard);
+router.get('/', controller.filterLeaderboard);
+router.get('/search', controller.filterByUser);
+router.get('/filter', controller.filterByUser);
 
 module.exports = router;

--- a/src/api/leaderboard/index.js
+++ b/src/api/leaderboard/index.js
@@ -4,8 +4,8 @@ const { verifyJWT } = require('../../utils/Middlewares');
 
 const router = Router();
 
-router.get('/', controller.filterLeaderboard);
-router.get('/search', controller.filterByUser);
-router.get('/filter', controller.filterByUser);
+router.get('/', controller.filterByUsers);
+router.get('/search', controller.filterByUsers);
+router.get('/filter', controller.filterByUsers);
 
 module.exports = router;


### PR DESCRIPTION
Changed the leaderboard API to 

- send the same type of response: `{contributors:[], meta:{currentPage: number, totalPages: number, totalUsers: number,}}`
- have less code duplications
- support all of the filters: minPoints, maxPoints, minPrs, page = 1, limit = 10, name

With this update the [Issue 21 in the Frontend](https://github.com/clubgamma/club-gamma-frontend/issues/21) needs only minor changes, and will be easier to maintain.