### PR TITLE
Implement new API endpoint: Project-wise contributions for users

### DIFF
--- a/src/api/users/controller.js
+++ b/src/api/users/controller.js
@@ -69,7 +69,6 @@ const getUserStats = async (req, res) => {
             mergedPRs: user.prs.filter(pr => pr.state === 'merged').length,
             openPRs: user.prs.filter(pr => pr.state === 'open').length,
             closedPRs: user.prs.filter(pr => pr.state === 'closed').length,
-            repositoryBreakdown: {},
             prs: user.prs,
             prCountPerDay: {}, // Store PR count per day here
         };
@@ -86,16 +85,6 @@ const getUserStats = async (req, res) => {
             // Increment the count for that date
             stats.prCountPerDay[date]++;
 
-            // Populate repository breakdown
-            if (!stats.repositoryBreakdown[pr.repository]) {
-                stats.repositoryBreakdown[pr.repository] = {
-                    total: 0,
-                    merged: 0,
-                    points: 0,
-                };
-            }
-
-            stats.repositoryBreakdown[pr.repository].total++;
         });
 
         // Respond with user stats and rank

--- a/src/api/users/controller.js
+++ b/src/api/users/controller.js
@@ -35,7 +35,33 @@ const getUserStats = async (req, res) => {
                 Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
             },
         });
+        
+        // Fetch contributions for each project
+        const contributors = await prisma.pullRequests.groupBy({
+            by: ['repository'],
+            _count: {
+                _all: true,
+            },
+            _sum: {
+                points: true,
+            },
+            where: {
+                authorId: {
+                    equals: githubId,
+                    mode: 'insensitive', // Make the comparison case insensitive
+                },
+            },
+        });
 
+        // Format the response
+        const projectContributions = contributors.map(contribution => ({
+            projectName: contribution.repository.split('/')[1], // Assuming repository is in format 'clubgamma/project-name'
+            prCount: contribution._count._all,
+            totalPoints: contribution._sum.points || 0,
+        }));
+
+        // Sort projects by PR count in descending order
+        projectContributions.sort((a, b) => b.prCount - a.prCount);
 
         const stats = {
             totalPRs: user.prs.length,
@@ -89,6 +115,7 @@ const getUserStats = async (req, res) => {
                 blog: githubData.data.blog,
             },
             stats,
+            projectContributions,
         });
     } catch (error) {
         console.error('Error fetching user stats:', error);
@@ -256,64 +283,7 @@ const syncPullRequests = async (req, res) => {
 };
 
 
-const getProjectWiseContributions = async (req, res) => {
-    const { githubId } = req.params;
-
-    if (!githubId) {
-        return res.status(404).json({ error: 'Github ID not found' });
-    }
-
-    try {
-        // Fetch contributions for each project
-        const contributors = await prisma.pullRequests.groupBy({
-            by: ['repository'],
-            _count: {
-                _all: true,
-            },
-            _sum: {
-                points: true,
-            },
-            where: {
-                authorId: githubId,
-            },
-        });
-
-        // Format the response
-        const projectContributions = contributors.map(contribution => ({
-            projectName: contribution.repository.split('/')[1], // Assuming repository is in format 'clubgamma/project-name'
-            prCount: contribution._count._all,
-            totalPoints: contribution._sum.points || 0,
-        }));
-
-        // Sort projects by PR count in descending order
-        projectContributions.sort((a, b) => b.prCount - a.prCount);
-
-        // Fetch user details
-        const user = await prisma.users.findUnique({
-            where: { githubId },
-            select: { name: true, points: true, rank: true },
-        });
-
-        if (!user) {
-            return res.status(404).json({ error: 'User not found' });
-        }
-
-        res.status(200).json({
-            githubId,
-            name: user.name,
-            totalPoints: user.points,
-            rank: user.rank,
-            contributions: projectContributions
-        });
-    } catch (error) {
-        console.error('Error fetching project-wise contributions:', error);
-        res.status(500).json({ error: 'Internal server error' });
-    }
-};
-
-
 module.exports = {
     getUserStats,
-    syncPullRequests,
-    getProjectWiseContributions
+    syncPullRequests
 }

--- a/src/api/users/index.js
+++ b/src/api/users/index.js
@@ -4,6 +4,7 @@ const { rateLimiting , verifyJWT } = require('../../utils/Middlewares');
 const router = Router();
 
 router.get('/stats/:githubId', controller.getUserStats);
+router.get('/contributors/:githubId', controller.getProjectWiseContributions);
 router.post('/sync-prs', verifyJWT , rateLimiting, controller.syncPullRequests);
 
 module.exports = router;

--- a/src/api/users/index.js
+++ b/src/api/users/index.js
@@ -4,7 +4,6 @@ const { rateLimiting , verifyJWT } = require('../../utils/Middlewares');
 const router = Router();
 
 router.get('/stats/:githubId', controller.getUserStats);
-router.get('/contributors/:githubId', controller.getProjectWiseContributions);
 router.post('/sync-prs', verifyJWT , rateLimiting, controller.syncPullRequests);
 
 module.exports = router;


### PR DESCRIPTION
### @jalaym825 We need to implement a new API endpoint that provides project-wise contribution details for a specific GitHub user. This endpoint will be crucial for displaying user activity across different projects in our application.

### Endpoint: GET /api/users/contributions/:githubId

## Requirements:
1. The endpoint should accept a GitHub ID as a path parameter.
2. It should return the following information:
   - User's GitHub ID
   - User's name
   - User's total points
   - User's rank
   - An array of contributions, where each entry contains:
     - Project name
     - Number of PRs for that project
     - Total points earned for that project

3. The contributions should be sorted by PR count in descending order.
4. If the user is not found, it should return a 404 error.
5. Proper error handling should be implemented for invalid inputs or server errors.

### Example response:
```json
{
  "githubId": "example-user",
  "name": "Example Name",
  "totalPoints": 32,
  "rank": 5,
  "contributions": [
    {
      "projectName": "club-gamma-frontend",
      "prCount": 15,
      "totalPoints": 45
    },
    {
      "projectName": "club-gamma-backend",
      "prCount": 10,
      "totalPoints": 30
    },
    {
      "projectName": "Internet-Speed-Tester",
      "prCount": 5,
      "totalPoints": 25
    }
  ]
}